### PR TITLE
Add ovs bridge vlan trunk example

### DIFF
--- a/examples/ovsbridge_vlan_port.yml
+++ b/examples/ovsbridge_vlan_port.yml
@@ -3,6 +3,9 @@ interfaces:
   - name: ovs0
     type: ovs-interface
     state: up
+  - name: ovs1
+    type: ovs-interface
+    state: up
   - name: ovs-br0
     type: ovs-bridge
     state: up
@@ -12,3 +15,11 @@ interfaces:
           vlan:
             mode: access
             tag: 2
+        - name: ovs1
+          vlan:
+            mode: trunk
+            trunk-tags:
+              - id: 1
+              - id-range:
+                  min: 10
+                  max: 20

--- a/rust/src/lib/nm/nm_dbus/gen_conf/ovs.rs
+++ b/rust/src/lib/nm/nm_dbus/gen_conf/ovs.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::nm::nm_dbus::ToDbusValue;
 use std::collections::HashMap;
 
 use super::super::{
@@ -9,10 +10,40 @@ use super::super::{
 };
 
 impl ToKeyfile for NmSettingOvsBridge {}
-impl ToKeyfile for NmSettingOvsPort {}
 impl ToKeyfile for NmSettingOvsIface {}
 impl ToKeyfile for NmSettingOvsPatch {}
 impl ToKeyfile for NmSettingOvsDpdk {}
+
+impl ToKeyfile for NmSettingOvsPort {
+    fn to_keyfile(&self) -> Result<HashMap<String, zvariant::Value>, NmError> {
+        let mut ret = HashMap::new();
+
+        for (k, v) in self.to_value()?.drain() {
+            if k != "trunks" {
+                ret.insert(k.to_string(), v);
+            }
+        }
+        if let Some(vlans) = self.trunks.as_ref() {
+            let mut vlans_clone = vlans.clone();
+            vlans_clone.sort_unstable_by_key(|v| v.start);
+            let mut vlans_str = Vec::new();
+            for vlan in vlans_clone {
+                let ret = if vlan.start == vlan.end {
+                    vlan.start.to_string()
+                } else {
+                    format!("{}-{}", vlan.start, vlan.end)
+                };
+                vlans_str.push(ret);
+            }
+            ret.insert(
+                "trunks".to_string(),
+                zvariant::Value::new(vlans_str.join(",")),
+            );
+        }
+
+        Ok(ret)
+    }
+}
 
 impl ToKeyfile for NmSettingOvsExtIds {
     fn to_keyfile(&self) -> Result<HashMap<String, zvariant::Value>, NmError> {


### PR DESCRIPTION
GenConf doesn't work for ovs-port trunk vlans:

example:
```yaml
interfaces:
  - name: ovs0
    type: ovs-interface
    state: up
  - name: ovs1
    type: ovs-interface
    state: up
  - name: ovs-br0
    type: ovs-bridge
    state: up
    bridge:
      port:
        - name: ovs0
          vlan:
            mode: access
            tag: 2
        - name: ovs1
          vlan:
            mode: trunk
            trunk-tags:
              - id: 1
              - id-range:
                  min: 10
                  max: 20
```
Adding this to the examples leads to failing test:

>state = {'interfaces': [{'name': 'ovs0', 'state': 'up', 'type': 'ovs-interface'}, {'name': 'ovs1', 'state': 'up', 'type': 'ovs...': 'ovs0', 'vlan': {...}}, {'name': 'ovs1', 'vlan': {...}}]}, 'name': 'ovs-br0', 'state': 'up', 'type': 'ovs-bridge'}]}
>
>    def gen_conf(state):
>        c_err_msg = c_char_p()
>        c_err_kind = c_char_p()
>        c_state = c_char_p(json.dumps(state).encode("utf-8"))
>        c_configs = c_char_p()
>        c_log = c_char_p()
>        rc = lib.nmstate_generate_configurations(
>            c_state,
>            byref(c_configs),
>            byref(c_log),
>            byref(c_err_kind),
>            byref(c_err_msg),
>        )
>        configs = c_configs.value
>        err_msg = c_err_msg.value
>        err_kind = c_err_kind.value
>        parse_log(c_log.value)
>        lib.nmstate_cstring_free(c_log)
>        lib.nmstate_cstring_free(c_err_kind)
>        lib.nmstate_cstring_free(c_err_msg)
>        if rc != NMSTATE_PASS:
>           raise map_error(err_kind, err_msg)
>E           libnmstate.error.NmstatePluginError: Bug in NM plugin, failed to generate configure: Bug:Cannot convert Dict Dict { entries: [DictEntry { key: Str(Str(Borrowed("start"))), value: Value(U64(1)) }, DictEntry { key: Str(Str(Borrowed("end"))), value: Value(U64(1)) }], key_signature: Signature: [
>E           	s (115),
>E           ], value_signature: Signature: [
>E           	v (118),
>E           ], signature: Signature: [
>E           	a (97),
>E           	{ (123),
>E           	s (115),
>E           	v (118),
>E           	} (125),
>E           ] } to key file format